### PR TITLE
Honor CSS background-size: cover; in container

### DIFF
--- a/draggable_background.js
+++ b/draggable_background.js
@@ -26,6 +26,26 @@
     e.clientY = e.originalEvent.touches[0].clientY
   }
 
+  var needsHorizontalScale = function(vp_dims, img_dims) {
+    var vp_ar  = vp_dims[0]  / vp_dims[1];
+    var img_ar = img_dims[0] / img_dims[1];
+
+    return (img_ar <= vp_ar);
+  };
+
+  var imageScaledDimensions = function(vp_dims, img_dims) {
+    var scale = 1;
+
+    if(needsHorizontalScale(vp_dims, img_dims)) {
+      scale = vp_dims[0]/img_dims[0];
+    }
+    else {
+      scale = vp_dims[1]/img_dims[1];
+    }
+
+    return [img_dims[0]*scale, img_dims[1]*scale];
+  };
+
   $.fn.backgroundDraggable = function(options) {
     var options = $.extend({}, $.fn.backgroundDraggable.defaults, options)
 
@@ -42,8 +62,16 @@
       if (options.bound) {
         var i = new Image
         i.onload = function() {
-          img.width = i.width
-          img.height = i.height
+          if($this.css("background-size") == "cover") {
+            var vp_dims = [$this.innerWidth(), $this.innerHeight()];
+            var scaled_dims = imageScaledDimensions(vp_dims, [i.width, i.height]);
+            img.width  = scaled_dims[0];
+            img.height = scaled_dims[1];
+          }
+          else {
+            img.width  = i.width
+            img.height = i.height
+          }
         }
         i.src = src[1]
       }

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       $('#unbounded').backgroundDraggable({ bound: false })
       $('#x').backgroundDraggable({ axis: 'x' })
       $('#y').backgroundDraggable({ axis: 'y' })
+      $('#background-cover').backgroundDraggable()
 
       $('div').each(function() {
         var $this = $(this)
@@ -25,8 +26,10 @@
 <body>
   <div id="default" style="background:url('http://pipsum.com/640x480.jpg')">default</div>
   <div id="unbounded" style="background:url('http://pipsum.com/640x480.jpg')">bound: false</div>
+  <div id="background-cover" style="background:url('http://pipsum.com/640x640.jpg'); background-size: cover;">background cover</div>
   <br><br>
   <div id="x" style="background:url('http://pipsum.com/2560x240.jpg')">axis: 'x'</div>
   <div id="y" style="background:url('http://pipsum.com/320x1600.jpg')">axis: 'y'</div>
+  <br><br>
 </body>
 </html>


### PR DESCRIPTION
When using background-size: cover the image dimensions are not correctly set. Here is my patch to fix this issue and scroll scaled backgrounds.
