### PR TITLE
Fix bug with background cover - add mouseout - add done callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ $('div').backgroundDraggable('disable');
 // callback when drag complete
 $('div').backgroundDraggable({
   done: function() {
-    console.log('dragging complete');
+    backgroundPosition = $('div').css('background-position');
+    console.log(backgroundPosition);
   }
 });
 ```

--- a/draggable_background.js
+++ b/draggable_background.js
@@ -113,19 +113,19 @@
       });
     });
 
-    $el.on('mouseup.dbg touchend.dbg', function() {
+    $el.on('mouseup.dbg touchend.dbg mouseleave.dbg', function() {
       if (options.done) {
         options.done();
       }
 
-      $el.off('mousemove.dbg touchmove.dbg');
       $window.off('mousemove.dbg touchmove.dbg');
     });
   };
 
   Plugin.prototype.disable = function() {
     var $el = $(this.element);
-    $el.off('mouseup.dbg mousedown.dbg touchstart.dbg touchend.dbg');
+    $el.off('mouseup.dbg mousedown.dbg touchstart.dbg touchend.dbg mouseleave.dbg');
+    $window.off('mousemove.dbg touchmove.dbg');
   }
 
   $.fn.backgroundDraggable = function(options) {


### PR DESCRIPTION
I had a bug with `background-size: cover` where it wasn't getting the size at the time of variable initialization, so I just moved that call in line.

I also added a `done` callback for when the user is done dragging. In the callback a user can just inspect the div and look at the `background-position` attribute if they want to use that in some way.

Also, I added the `mouseout` event, for when you are dragging the background image and move the mouse outside of the div and do a mouseup. The current implementation does not "let go" of the image.

I'd be more than happy to make any changes you think this may need, or split it out into multiple pull-requests as well if you want.
