### PR TITLE
Background position limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ A jQuery plugin to make background images draggable.
     <td>Whether dragging is triggered by inner elements.</td>
   </tr>
   <tr>
+    <td>frame</td>
+    <td>Integer</td>
+    <td></td>
+    <td></td>
+    <td>If specified, restrict dragging to an inner frame. Don't let background get out of container boundaries</td>
+  </tr>
+  <tr>
     <td>axis</td>
     <td>String</td>
     <td>x|y</td>
@@ -48,6 +55,9 @@ $('div').backgroundDraggable();
 
 // only draggable in the x direction, and dragging is not bounded by the image
 $('div').backgroundDraggable({ bound: false, axis: 'x' });
+
+// limit background position to an inner frame 50px from each side
+$('div').backgroundDraggable({ frame: 50 });
 
 // disable draggable background
 $('div').backgroundDraggable('disable');

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ A jQuery plugin to make background images draggable.
     <td>Whether dragging is bounded by the edges of the image.</td>
   </tr>
   <tr>
+    <td>propagate</td>
+    <td>Boolean</td>
+    <td>true|false</td>
+    <td>false</td>
+    <td>Whether dragging is triggered by inner elements.</td>
+  </tr>
+  <tr>
     <td>axis</td>
     <td>String</td>
     <td>x|y</td>

--- a/draggable_background.js
+++ b/draggable_background.js
@@ -80,7 +80,7 @@
     }
 
     $el.on('mousedown.dbg touchstart.dbg', function(e) {
-      if (e.target !== $el[0]) {
+      if (!options.propagate && e.target !== $el[0]) {
         return;
       }
       e.preventDefault();
@@ -152,6 +152,7 @@
 
   $.fn.backgroundDraggable.defaults = {
     bound: true,
+    propagate: false,
     axis: undefined
   };
 }(jQuery));

--- a/draggable_background.js
+++ b/draggable_background.js
@@ -79,6 +79,11 @@
       imageDimensions = getBackgroundImageDimensions($el);
     }
 
+    var boundaries = {
+      x: { lo: $el.innerWidth(),  hi: 0},
+      y: { lo: $el.innerHeight(), hi: 0}
+    };
+
     $el.on('mousedown.dbg touchstart.dbg', function(e) {
       if (!options.propagate && e.target !== $el[0]) {
         return;
@@ -89,6 +94,18 @@
         modifyEventForTouch(e);
       } else if (e.which !== 1) {
         return;
+      }
+
+      if (options.bound) {
+        boundaries.x.lo = $el.innerWidth() -  imageDimensions.width;
+        boundaries.y.lo = $el.innerHeight() - imageDimensions.height;
+
+        if (typeof(options.frame) === 'number') {
+          boundaries.x.lo = - imageDimensions.width + options.frame;
+          boundaries.x.hi = $el.innerWidth() - options.frame;
+          boundaries.y.lo = - imageDimensions.height + options.frame;
+          boundaries.y.hi = $el.innerHeight() - options.frame;
+        }
       }
 
       var x0 = e.clientX,
@@ -107,8 +124,8 @@
         var x = e.clientX,
             y = e.clientY;
 
-        xPos = options.axis === 'y' ? xPos : limit($el.innerWidth()-imageDimensions.width, 0, xPos+x-x0, options.bound);
-        yPos = options.axis === 'x' ? yPos : limit($el.innerHeight()-imageDimensions.height, 0, yPos+y-y0, options.bound);
+        xPos = options.axis === 'y' ? xPos : limit(boundaries.x.lo, boundaries.x.hi, xPos + x - x0, options.bound);
+        yPos = options.axis === 'x' ? yPos : limit(boundaries.y.lo, boundaries.y.hi, yPos + y - y0, options.bound);
         x0 = x;
         y0 = y;
 
@@ -153,6 +170,7 @@
   $.fn.backgroundDraggable.defaults = {
     bound: true,
     propagate: false,
+    frame: undefined,
     axis: undefined
   };
 }(jQuery));

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       $('#unbounded').backgroundDraggable({ bound: false });
       $('#x').backgroundDraggable({ axis: 'x' });
       $('#y').backgroundDraggable({ axis: 'y' });
+      $('#propagate').backgroundDraggable({ propagate: true });
 
       $('div').each(function() {
         var $this = $(this),
@@ -28,5 +29,7 @@
   <br><br>
   <div id="x" style="background:url('http://pipsum.com/2560x240.jpg')">axis: 'x'</div>
   <div id="y" style="background:url('http://pipsum.com/320x1600.jpg')">axis: 'y'</div>
+  <br><br>
+  <div id="propagate" style="background:url('http://pipsum.com/640x480.jpg')">propagate: true (drag from here)</div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       $('#x').backgroundDraggable({ axis: 'x' });
       $('#y').backgroundDraggable({ axis: 'y' });
       $('#propagate').backgroundDraggable({ propagate: true });
+      $('#frame').backgroundDraggable({ frame: 50 });
 
       $('div').each(function() {
         var $this = $(this),
@@ -31,5 +32,6 @@
   <div id="y" style="background:url('http://pipsum.com/320x1600.jpg')">axis: 'y'</div>
   <br><br>
   <div id="propagate" style="background:url('http://pipsum.com/640x480.jpg')">propagate: true (drag from here)</div>
+  <div id="frame" style="background:#222 url('http://pipsum.com/640x480.jpg') no-repeat">frame: 50</div>
 </body>
 </html>


### PR DESCRIPTION
# Problem
Fully move background image within container limits.
Using "bound: false" and "background-repeat: no-repeat" you can move the image out of sight.

# Solution
Limit background movement to prevent getting out of sight.
Additionally adding an inner frame to constraint how close to the borders can the background get, allowing the image to be always be visible at least those pixels

# Implementation
New option "frame" indicates number of pixels to limit background movement. Only used when "bound: true"
Frame option is best viewed with "background-repeat: no-repeat"
Calculate boundaries for background position when "bound: true" and a frame is provided so you can move background freely inside container boundaries limited by frame.

# Extra
The ability to trigger drag from inner elements (in the example from <p> elements) is desirable in some situations. Added a "propagate" option for this