### PR TITLE
Fix odd rounding errors

### DIFF
--- a/draggable_background.js
+++ b/draggable_background.js
@@ -112,7 +112,7 @@
         x0 = x;
         y0 = y;
 
-        $el.css('background-position', xPos + 'px ' + yPos + 'px');
+        $el.css('background-position', Math.round(xPos) + 'px ' + Math.round(yPos) + 'px');
       });
 
       $window.on('mouseup.dbg touchend.dbg mouseleave.dbg', function() {


### PR DESCRIPTION
I know you're not maintaining this, but thought I'd send this just in case someone else finds it useful. I was finding that the background was jumping around on me in Chrome. It turned out that for very long decimals, it was rendering the numbers as scientific numbers and then concatenating them to 'px' and treating 0.00000000000005 px the same as 5px. This rounds up to a whole pixel value.

Prevent this behavior: 

``` javascript
(450 - 449.99999999999994) + 'px' 
"5.684341886080802e-14px"
```
